### PR TITLE
No more deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,33 +65,33 @@ const updatedTree = pipe(
     (t) => removeAlpha(t, { name: 'Luke' })
 )(unbalancedTree);
 
-// unbalancedTree:                           | Schema of "unbalancedTree"
-//                                           |
-// {                                         |             Han
-//     data: { name: 'Han' },                |           /     \
-//     left: {                               |     Anakin       Leia
-//         data: { name: 'Anakin' },         |           \     /    \
-//         right: {                          |       Chewie  Lando   Luke
-//             data : { name: 'Chewie' },    |                         \
-//         },                                |                        Padme
-//     },                                    |
-//     right: {                              | Schema of "updatedTree"
-//         data: { name: 'Leia' },           |
-//         left: {                           |            Lando
-//             data: { name: 'Lando' },      |           /     \
-//         },                                |     Anakin       Leia
-//         right: {                          |         \            \
-//             data: { name: 'Luke' },       |       Chewie        Obiwan
-//             right: {                      |        /    \            \
-//                 data : { name: 'Padme' }, |      Boba  Grogu        Yoda
-//             },                            |
-//         },                                |
-//     },                                    |
-// };                                        |
+// unbalancedTree:                             | Schema of "unbalancedTree"
+//                                             |
+// {                                           |             Han
+//     data: [{ name: 'Han' }],                |           /     \
+//     left: {                                 |     Anakin       Leia
+//         data: [{ name: 'Anakin' }],         |           \     /    \
+//         right: {                            |       Chewie  Lando   Luke
+//             data : [{ name: 'Chewie' }],    |                         \
+//         },                                  |                        Padme
+//     },                                      |
+//     right: {                                | Schema of "updatedTree"
+//         data: [{ name: 'Leia' }],           |
+//         left: {                             |            Lando
+//             data: [{ name: 'Lando' }],      |           /     \
+//         },                                  |     Anakin       Leia
+//         right: {                            |         \            \
+//             data: [{ name: 'Luke' }],       |       Chewie        Obiwan
+//             right: {                        |        /    \            \
+//                 data : [{ name: 'Padme' }], |      Boba  Grogu        Yoda
+//             },                              |
+//         },                                  |
+//     },                                      |
+// };                                          |
 
-const min = findMin(updatedTree).data.name; // Anakin
-const max = findMax(updatedTree).data.name; // Yoda
-const grogu = findAlpha(updatedTree, { name: 'Grogu' }).node.data.name; // Grogu
+const min = findMin(updatedTree).data[0].name; // Anakin
+const max = findMax(updatedTree).data[0].name; // Yoda
+const grogu = findAlpha(updatedTree, { name: 'Grogu' }).node.data[0].name; // Grogu
 const groguPath = findAlpha(updatedTree, { name: 'Grogu' }).path; // ['left', 'right', 'right']
 // Thanks to the compare function, the search will traverse like this:
 // Lando -> Anakin -> Chewie -> Grogu
@@ -231,7 +231,7 @@ const {
     node: { data },
     path,
 } = find(tree, compare, 13);
-// data: 13
+// data: [13]
 // path: ['right', 'left']
 // or
 const safeFind = makeFind(compare);
@@ -239,7 +239,7 @@ const {
     node: { data },
     path,
 } = safeFind(tree, 13);
-// data: 13
+// data: [13]
 // path: ['right', 'left']
 ```
 
@@ -267,11 +267,11 @@ Finds all gt/gte/lt/lte nodes into the given binary search tree with the given c
 //           /
 //         50
 
-const results = findGte(tree, compare, 4).map(({ node, path: _path }) => node.data);
+const results = findGte(tree, compare, 4).flatMap(({ node, path: _path }) => node.data[0]);
 // [10, 5, 32, 13, 89, 50]
 // or
 const safeFindGte = makeFindGte(compare);
-const results = safeFindGte(tree, 4).map(({ node, path: _path }) => node.data);
+const results = safeFindGte(tree, 4).flatMap(({ node, path: _path }) => node.data[0]);
 // [10, 5, 32, 13, 89, 50]
 ```
 
@@ -294,8 +294,8 @@ Counts (`count`) the nodes in the tree
 //           /
 //         50
 
-const min = findMin(tree).data; // 2
-const max = findMax(tree).data; // 89
+const min = findMin(tree).data[0]; // 2
+const max = findMax(tree).data[0]; // 89
 const minHeight = findMinHeight(tree); // 1
 const maxHeight = findMaxHeight(tree); // 3
 const length = count(tree); // 7
@@ -330,8 +330,8 @@ Traverses a tree, invoking the callback function on each visited node.
 //           /
 //         50
 
-const collect = (collection: number[]) => (node: { data: number }) => {
-    collection.push(node.data);
+const collect = (collection: number[]) => (node: { data: number[] }) => {
+    node.data.forEach((e) => collection.push(e));
 };
 
 const elements = [];
@@ -555,9 +555,9 @@ bst.add({ name: 'Yoda' })
 //        /    \            \
 //      Boba  Grogu        Yoda
 
-bst.findMin().data.name; // Anakin
-bst.findMax().data.name; // Yoda
-bst.find({ name: 'Grogu' }).node.data.name; // Grogu
+bst.findMin().data[0].name; // Anakin
+bst.findMax().data[0].name; // Yoda
+bst.find({ name: 'Grogu' }).node.data[0].name; // Grogu
 bst.find({ name: 'Grogu' }).path; // ['left', 'right', 'right']
 // Thanks to the compare function, the search will traverse like this:
 // Lando -> Anakin -> Chewie -> Grogu

--- a/jest.config.json
+++ b/jest.config.json
@@ -4,6 +4,7 @@
     "testEnvironment": "node",
     "moduleDirectories": ["node_modules", "test"],
     "testMatch": ["**/*.test.ts"],
+    "collectCoverageFrom": ["./src/functions/**/*.ts", "./src/classes/**/*.ts"],
     "transform": {
         "`^.+\\.tsx?$`": [
             "ts-jest",

--- a/src/__tests__/_mocks.ts
+++ b/src/__tests__/_mocks.ts
@@ -22,49 +22,49 @@ export const mockedArrayLevelOrderReverse = [10, 32, 2, 89, 13, 5, 50];
 //          50
 
 export const mockedUnbalancedTree: BST<number> = {
-    data : 10,
+    data : [10],
     left : {
-        data  : 2,
+        data  : [2],
         right : {
-            data : 5,
+            data : [5],
         },
     },
     right : {
-        data : 32,
+        data : [32],
         left : {
-            data : 13,
+            data : [13],
         },
         right : {
-            data : 89,
+            data : [89],
             left : {
-                data : 50,
+                data : [50],
             },
         },
     },
 };
 
 export const mockedBalancedTree: BST<number> = {
-    data : 13,
+    data : [13],
     left : {
-        data : 5,
+        data : [5],
         left : {
-            data : 2,
+            data : [2],
         },
         right : {
-            data : 10,
+            data : [10],
         },
     },
     right : {
-        data : 50,
+        data : [50],
         left : {
-            data : 32,
+            data : [32],
         },
         right : {
-            data : 89,
+            data : [89],
         },
     },
 };
 
-export const mockedLeaf = (mockedUnbalancedTree.left as BST<number>).right;
-export const mockedStrictLeftLeaf = (mockedUnbalancedTree.right as BST<number>).right;
-export const mockedStrictRightLeaf = mockedUnbalancedTree.left;
+export const mockedLeaf = mockedUnbalancedTree.left?.right as BST<number>;
+export const mockedStrictLeftLeaf = mockedUnbalancedTree?.right?.right as BST<number>;
+export const mockedStrictRightLeaf = mockedUnbalancedTree.left as BST<number>;

--- a/src/__tests__/add.test.ts
+++ b/src/__tests__/add.test.ts
@@ -4,61 +4,61 @@ import { compare, mockedUnbalancedTree } from './_mocks';
 describe('add', () => {
     const boundAdd = makeAdd(compare);
 
-    it('should not add a node which is already there', () => {
+    it('should not deduplicate when adding an element which is already there', () => {
         const tree = add(mockedUnbalancedTree, compare, 10);
-        expect(tree).toEqual(mockedUnbalancedTree);
+        expect(tree.data).toEqual([10, 10]);
 
         const treeWithBound = boundAdd(mockedUnbalancedTree, 10);
-        expect(treeWithBound).toEqual(mockedUnbalancedTree);
+        expect(treeWithBound.data).toEqual([10, 10]);
     });
 
     it('should add a node to and empty tree', () => {
-        const tree = add({}, compare, 10);
-        expect(tree?.data).toBe(10);
+        const tree = add({ data: [] }, compare, 10);
+        expect(tree?.data?.[0]).toBe(10);
 
-        const treeWithBound = boundAdd({}, 10);
-        expect(treeWithBound?.data).toBe(10);
+        const treeWithBound = boundAdd({ data: [] }, 10);
+        expect(treeWithBound?.data?.[0]).toBe(10);
     });
 
     it('should add a random node to the tree at the correct position', () => {
         const tree = add(mockedUnbalancedTree, compare, 11);
-        expect(tree.right?.left?.left?.data).toBe(11);
+        expect(tree.right?.left?.left?.data?.[0]).toBe(11);
 
         const treeWithBound = boundAdd(mockedUnbalancedTree, 11);
-        expect(treeWithBound.right?.left?.left?.data).toBe(11);
+        expect(treeWithBound.right?.left?.left?.data?.[0]).toBe(11);
     });
 
     it('should add a left node to the tree at the correct left-side position', () => {
         const tree = add(mockedUnbalancedTree, compare, 0);
-        expect(tree.left?.left?.data).toBe(0);
+        expect(tree.left?.left?.data?.[0]).toBe(0);
 
         const treeWithBound = boundAdd(mockedUnbalancedTree, 0);
-        expect(treeWithBound.left?.left?.data).toBe(0);
+        expect(treeWithBound.left?.left?.data?.[0]).toBe(0);
     });
 
     it('should add a right node to the tree at the correct right-side position', () => {
         const tree = add(mockedUnbalancedTree, compare, 100);
-        expect(tree.right?.right?.right?.data).toBe(100);
+        expect(tree.right?.right?.right?.data?.[0]).toBe(100);
 
         const treeWithBound = boundAdd(mockedUnbalancedTree, 100);
-        expect(treeWithBound.right?.right?.right?.data).toBe(100);
+        expect(treeWithBound.right?.right?.right?.data?.[0]).toBe(100);
     });
 
-    it('should not add a node which is already there', () => {
+    it('should not deduplicate when adding an element which is already there', () => {
         const tree = add(mockedUnbalancedTree, compare, [10]);
-        expect(tree).toEqual(mockedUnbalancedTree);
+        expect(tree.data).toEqual([10, 10]);
 
         const treeWithBound = boundAdd(mockedUnbalancedTree, [10]);
-        expect(treeWithBound).toEqual(mockedUnbalancedTree);
+        expect(treeWithBound.data).toEqual([10, 10]);
     });
 
     it('should add a random node to the tree at the correct position', () => {
         const tree = add(mockedUnbalancedTree, compare, [11, 100]);
-        expect(tree.right?.left?.left?.data).toBe(11);
-        expect(tree.right?.right?.right?.data).toBe(100);
+        expect(tree.right?.left?.left?.data?.[0]).toBe(11);
+        expect(tree.right?.right?.right?.data?.[0]).toBe(100);
 
         const treeWithBound = boundAdd(mockedUnbalancedTree, [11, 100]);
-        expect(treeWithBound.right?.left?.left?.data).toBe(11);
-        expect(treeWithBound.right?.right?.right?.data).toBe(100);
+        expect(treeWithBound.right?.left?.left?.data?.[0]).toBe(11);
+        expect(treeWithBound.right?.right?.right?.data?.[0]).toBe(100);
     });
 });

--- a/src/__tests__/add.test.ts
+++ b/src/__tests__/add.test.ts
@@ -1,4 +1,5 @@
 import { add, makeAdd } from '../functions/add';
+import { toArrayInOrder } from '../functions/to-array';
 import { compare, mockedUnbalancedTree } from './_mocks';
 
 describe('add', () => {
@@ -18,6 +19,14 @@ describe('add', () => {
 
         const treeWithBound = boundAdd({ data: [] }, 10);
         expect(treeWithBound?.data?.[0]).toBe(10);
+    });
+
+    it('should not mutate the original tree', () => {
+        const tree = add({ data: [] }, compare, [10, 20, 30]);
+        const updatedTree = add(tree, compare, [40, 50]);
+
+        expect(toArrayInOrder(tree).length).toBe(3);
+        expect(toArrayInOrder(updatedTree).length).toBe(5);
     });
 
     it('should add a random node to the tree at the correct position', () => {

--- a/src/__tests__/binary-search-tree.test.ts
+++ b/src/__tests__/binary-search-tree.test.ts
@@ -39,7 +39,7 @@ describe('BinarySearchTree', () => {
 
     it('should add a node correctly', () => {
         const { tree } = new BinarySearchTree(mockedArray, compare, { isBalanced: false }).add(11);
-        expect(tree.right?.left?.left?.data).toBe(11);
+        expect(tree.right?.left?.left?.data[0]).toBe(11);
     });
 
     it('should fill the tree correctly', () => {
@@ -51,13 +51,13 @@ describe('BinarySearchTree', () => {
         const { tree } = new BinarySearchTree(mockedArray, compare, { isBalanced: false }).remove(
             50
         );
-        expect(tree?.right?.right?.data).toBe(89);
-        expect(tree?.right?.right?.left?.data).toBe(undefined);
+        expect(tree?.right?.right?.data[0]).toBe(89);
+        expect(tree?.right?.right?.left?.data[0]).toBe(undefined);
     });
 
     it('should empty the tree correctly', () => {
         const { tree } = new BinarySearchTree(mockedArray, compare).remove(mockedArray);
-        expect(tree).toEqual({});
+        expect(tree).toEqual({ data: [] });
     });
 
     // ___ Traversals ___
@@ -206,49 +206,84 @@ describe('BinarySearchTree', () => {
 
     it('should find correctly', () => {
         const node = new BinarySearchTree(mockedArray, compare).find(10)?.node;
-        expect(node?.data).toEqual(10);
+        expect(node?.data[0]).toEqual(10);
+    });
+
+    it('should not find correctly', () => {
+        const node = new BinarySearchTree(mockedArray, compare).find(20)?.node;
+        expect(node?.data[0]).toEqual(undefined);
     });
 
     it('should findGt correctly', () => {
         const results = new BinarySearchTree(mockedArray, compare, { isBalanced: false }).findGt(
             10
         );
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data[0]);
         expect(mapped).toEqual([32, 13, 89, 50]);
+    });
+
+    it('should not findGt correctly', () => {
+        const results = new BinarySearchTree(mockedArray, compare, { isBalanced: false }).findGt(
+            100
+        );
+        const mapped = results.flatMap(({ node }) => node?.data[0]);
+        expect(mapped).toEqual([]);
     });
 
     it('should findGte correctly', () => {
         const results = new BinarySearchTree(mockedArray, compare, { isBalanced: false }).findGte(
             10
         );
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data[0]);
         expect(mapped).toEqual([10, 32, 13, 89, 50]);
+    });
+
+    it('should not findGte correctly', () => {
+        const results = new BinarySearchTree(mockedArray, compare, { isBalanced: false }).findGte(
+            100
+        );
+        const mapped = results.flatMap(({ node }) => node?.data[0]);
+        expect(mapped).toEqual([]);
     });
 
     it('should findLt correctly', () => {
         const results = new BinarySearchTree(mockedArray, compare, { isBalanced: false }).findLt(
             13
         );
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data[0]);
         expect(mapped).toEqual([10, 2, 5]);
+    });
+
+    it('should not findLt correctly', () => {
+        const results = new BinarySearchTree(mockedArray, compare, { isBalanced: false }).findLt(0);
+        const mapped = results.flatMap(({ node }) => node?.data[0]);
+        expect(mapped).toEqual([]);
     });
 
     it('should findLte correctly', () => {
         const results = new BinarySearchTree(mockedArray, compare, { isBalanced: false }).findLte(
             13
         );
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data[0]);
         expect(mapped).toEqual([10, 2, 5, 13]);
+    });
+
+    it('should not findLte correctly', () => {
+        const results = new BinarySearchTree(mockedArray, compare, { isBalanced: false }).findLte(
+            0
+        );
+        const mapped = results.flatMap(({ node }) => node?.data[0]);
+        expect(mapped).toEqual([]);
     });
 
     it('should findMin correctly', () => {
         const node = new BinarySearchTree(mockedArray, compare).findMin();
-        expect(node?.data).toEqual(2);
+        expect(node?.data[0]).toEqual(2);
     });
 
     it('should findMax correctly', () => {
         const node = new BinarySearchTree(mockedArray, compare).findMax();
-        expect(node?.data).toEqual(89);
+        expect(node?.data[0]).toEqual(89);
     });
 
     it('should findMinHeight correctly', () => {
@@ -296,5 +331,10 @@ describe('BinarySearchTree', () => {
         const bst = new BinarySearchTree(mockedArray, compare, { isBalanced: false });
         expect(bst.isLeaf(5)).toEqual(true);
         expect(bst.isLeaf(10)).toEqual(false);
+    });
+
+    it('should clear correctly', () => {
+        const bst = new BinarySearchTree(mockedArray, compare, { isBalanced: false });
+        expect(bst.clear().tree).toEqual({ data: [] });
     });
 });

--- a/src/__tests__/find-gt.test.ts
+++ b/src/__tests__/find-gt.test.ts
@@ -4,13 +4,13 @@ import { compare, mockedUnbalancedTree } from './_mocks';
 describe('findGt', () => {
     it('should findGt all nodes which are greater than the element', () => {
         const results = findGt(mockedUnbalancedTree, compare, 10);
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([32, 13, 89, 50]);
     });
 
     it('should not findGt a node in an empty tree', () => {
-        const results = findGt({}, compare, 10);
-        const mapped = results.map(({ node }) => node?.data);
+        const results = findGt({ data: [] }, compare, 10);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([]);
     });
 });
@@ -20,13 +20,13 @@ describe('makeFindGt', () => {
 
     it('should findGt all nodes which are greater than the element', () => {
         const results = boundFindGt(mockedUnbalancedTree, 10);
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([32, 13, 89, 50]);
     });
 
     it('should not findGt a node in an empty tree', () => {
-        const results = boundFindGt({}, 10);
-        const mapped = results.map(({ node }) => node?.data);
+        const results = boundFindGt({ data: [] }, 10);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([]);
     });
 });

--- a/src/__tests__/find-gte.test.ts
+++ b/src/__tests__/find-gte.test.ts
@@ -4,13 +4,13 @@ import { compare, mockedUnbalancedTree } from './_mocks';
 describe('findGte', () => {
     it('should findGte all nodes which are greater or equal than the element', () => {
         const results = findGte(mockedUnbalancedTree, compare, 10);
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([10, 32, 13, 89, 50]);
     });
 
     it('should not findGte a node in an empty tree', () => {
-        const results = findGte({}, compare, 10);
-        const mapped = results.map(({ node }) => node?.data);
+        const results = findGte({ data: [] }, compare, 10);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([]);
     });
 });
@@ -20,13 +20,13 @@ describe('makeFindGte', () => {
 
     it('should findGte all nodes which are greater or equal than the element', () => {
         const results = boundFindGte(mockedUnbalancedTree, 10);
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([10, 32, 13, 89, 50]);
     });
 
     it('should not findGte a node in an empty tree', () => {
-        const results = boundFindGte({}, 10);
-        const mapped = results.map(({ node }) => node?.data);
+        const results = boundFindGte({ data: [] }, 10);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([]);
     });
 });

--- a/src/__tests__/find-lt.test.ts
+++ b/src/__tests__/find-lt.test.ts
@@ -4,13 +4,13 @@ import { compare, mockedUnbalancedTree } from './_mocks';
 describe('findLt', () => {
     it('should findLt all nodes which are lesser than the element', () => {
         const results = findLt(mockedUnbalancedTree, compare, 13);
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([10, 2, 5]);
     });
 
     it('should not findLt a node in an empty tree', () => {
-        const results = findLt({}, compare, 13);
-        const mapped = results.map(({ node }) => node?.data);
+        const results = findLt({ data: [] }, compare, 13);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([]);
     });
 });
@@ -20,13 +20,13 @@ describe('makeFindLt', () => {
 
     it('should findLt all nodes which are lesser than the element', () => {
         const results = boundFindLt(mockedUnbalancedTree, 13);
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([10, 2, 5]);
     });
 
     it('should not findLt a node in an empty tree', () => {
-        const results = boundFindLt({}, 13);
-        const mapped = results.map(({ node }) => node?.data);
+        const results = boundFindLt({ data: [] }, 13);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([]);
     });
 });

--- a/src/__tests__/find-lte.test.ts
+++ b/src/__tests__/find-lte.test.ts
@@ -4,13 +4,13 @@ import { compare, mockedUnbalancedTree } from './_mocks';
 describe('findLte', () => {
     it('should findLte all nodes which are lesser or equal than the element', () => {
         const results = findLte(mockedUnbalancedTree, compare, 13);
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([10, 2, 5, 13]);
     });
 
     it('should not findLte a node in an empty tree', () => {
-        const results = findLte({}, compare, 13);
-        const mapped = results.map(({ node }) => node?.data);
+        const results = findLte({ data: [] }, compare, 13);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([]);
     });
 });
@@ -20,13 +20,13 @@ describe('makeFindLte', () => {
 
     it('should findLte all nodes which are lesser or equal than the element', () => {
         const results = boundFindLte(mockedUnbalancedTree, 13);
-        const mapped = results.map(({ node }) => node?.data);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([10, 2, 5, 13]);
     });
 
     it('should not findLte a node in an empty tree', () => {
-        const results = boundFindLte({}, 13);
-        const mapped = results.map(({ node }) => node?.data);
+        const results = boundFindLte({ data: [] }, 13);
+        const mapped = results.flatMap(({ node }) => node?.data);
         expect(mapped).toEqual([]);
     });
 });

--- a/src/__tests__/find-max.test.ts
+++ b/src/__tests__/find-max.test.ts
@@ -3,6 +3,6 @@ import { mockedUnbalancedTree } from './_mocks';
 
 describe('findMax', () => {
     it('should return the maximal value of the tree', () => {
-        expect(findMax(mockedUnbalancedTree).data).toBe(89);
+        expect(findMax(mockedUnbalancedTree).data[0]).toBe(89);
     });
 });

--- a/src/__tests__/find-min.test.ts
+++ b/src/__tests__/find-min.test.ts
@@ -3,6 +3,6 @@ import { mockedUnbalancedTree } from './_mocks';
 
 describe('findMin', () => {
     it('should return the minimal value of the tree', () => {
-        expect(findMin(mockedUnbalancedTree).data).toBe(2);
+        expect(findMin(mockedUnbalancedTree).data[0]).toBe(2);
     });
 });

--- a/src/__tests__/find.test.ts
+++ b/src/__tests__/find.test.ts
@@ -4,28 +4,28 @@ import { compare, mockedUnbalancedTree } from './_mocks';
 describe('find', () => {
     it('should not find a node which is not into the tree', () => {
         const node = find(mockedUnbalancedTree, compare, 11)?.node;
-        expect(node?.data).toBe(undefined);
+        expect(node?.data[0]).toBe(undefined);
     });
 
     it('should not find a node in an empty tree', () => {
-        const node = find({}, compare, 0)?.node;
-        expect(node?.data).toBe(undefined);
+        const node = find({ data: [] }, compare, 0)?.node;
+        expect(node?.data[0]).toBe(undefined);
     });
 
     it('should find a random node into the tree at the correct position', () => {
         const result = find(mockedUnbalancedTree, compare, 89);
         expect(result?.path).toEqual(['right', 'right']);
-        expect(result?.node?.data).toBe(89);
+        expect(result?.node?.data[0]).toBe(89);
     });
 
     it('should find a left node into the tree at the correct left-side position', () => {
         const node = find(mockedUnbalancedTree, compare, 2)?.node;
-        expect(node?.data).toBe(2);
+        expect(node?.data[0]).toBe(2);
     });
 
     it('should find a right node into the tree at the correct right-side position', () => {
         const node = find(mockedUnbalancedTree, compare, 50)?.node;
-        expect(node?.data).toBe(50);
+        expect(node?.data[0]).toBe(50);
     });
 });
 
@@ -34,27 +34,27 @@ describe('makeFind', () => {
 
     it('should not find a node which is not into the tree', () => {
         const node = boundFind(mockedUnbalancedTree, 11)?.node;
-        expect(node?.data).toBe(undefined);
+        expect(node?.data[0]).toBe(undefined);
     });
 
     it('should not find a node in an empty tree', () => {
-        const node = boundFind({}, 0)?.node;
-        expect(node?.data).toBe(undefined);
+        const node = boundFind({ data: [] }, 0)?.node;
+        expect(node?.data[0]).toBe(undefined);
     });
 
     it('should find a random node into the tree at the correct position', () => {
         const result = boundFind(mockedUnbalancedTree, 89);
         expect(result?.path).toEqual(['right', 'right']);
-        expect(result?.node?.data).toBe(89);
+        expect(result?.node?.data[0]).toBe(89);
     });
 
     it('should find a left node into the tree at the correct left-side position', () => {
         const node = boundFind(mockedUnbalancedTree, 2)?.node;
-        expect(node?.data).toBe(2);
+        expect(node?.data[0]).toBe(2);
     });
 
     it('should find a right node into the tree at the correct right-side position', () => {
         const node = boundFind(mockedUnbalancedTree, 50)?.node;
-        expect(node?.data).toBe(50);
+        expect(node?.data[0]).toBe(50);
     });
 });

--- a/src/__tests__/has-left.test.ts
+++ b/src/__tests__/has-left.test.ts
@@ -23,11 +23,7 @@ describe('hasLeft', () => {
         expect(hasLeft(mockedLeaf)).toBe(false);
     });
 
-    it('should return false when the given tree is undefined', () => {
-        expect(hasLeft()).toBe(false);
-    });
-
     it('should return false when the given tree has no data', () => {
-        expect(hasLeft({ data: undefined })).toBe(false);
+        expect(hasLeft({ data: [] })).toBe(false);
     });
 });

--- a/src/__tests__/has-right.test.ts
+++ b/src/__tests__/has-right.test.ts
@@ -23,11 +23,7 @@ describe('hasRight', () => {
         expect(hasRight(mockedLeaf)).toBe(false);
     });
 
-    it('should return false when the given tree is undefined', () => {
-        expect(hasRight()).toBe(false);
-    });
-
     it('should return false when the given tree has no data', () => {
-        expect(hasRight({ data: undefined })).toBe(false);
+        expect(hasRight({ data: [] })).toBe(false);
     });
 });

--- a/src/__tests__/is-branch.test.ts
+++ b/src/__tests__/is-branch.test.ts
@@ -23,11 +23,7 @@ describe('isBranch', () => {
         expect(isBranch(mockedLeaf)).toBe(false);
     });
 
-    it('should return false when the given tree is undefined', () => {
-        expect(isBranch()).toBe(false);
-    });
-
     it('should return false when the given tree has no data', () => {
-        expect(isBranch({ data: undefined })).toBe(false);
+        expect(isBranch({ data: [] })).toBe(false);
     });
 });

--- a/src/__tests__/is-leaf.test.ts
+++ b/src/__tests__/is-leaf.test.ts
@@ -10,19 +10,15 @@ describe('isLeaf', () => {
         expect(isLeaf(mockedUnbalancedTree)).toBe(false);
     });
 
-    it('should return false when the given tree is undefined', () => {
-        expect(isLeaf()).toBe(false);
-    });
-
     it('should return false when the given tree has no data', () => {
-        expect(isLeaf({ data: undefined })).toBe(false);
+        expect(isLeaf({ data: [] })).toBe(false);
     });
 
     it('should return false when the given tree has no left branch', () => {
-        expect(isLeaf({ data: 0, right: { data: 1 } })).toBe(false);
+        expect(isLeaf({ data: [0], right: { data: [1] } })).toBe(false);
     });
 
     it('should return false when the given tree has no right branch', () => {
-        expect(isLeaf({ data: 0, left: { data: 1 } })).toBe(false);
+        expect(isLeaf({ data: [0], left: { data: [1] } })).toBe(false);
     });
 });

--- a/src/__tests__/remove.test.ts
+++ b/src/__tests__/remove.test.ts
@@ -1,8 +1,12 @@
-import { makeRemove, remove } from '../functions/remove';
+import { makeCompareUtils } from '../functions/make-compare-utils';
+import { remove } from '../functions/remove';
+import { toArrayInOrder } from '../functions/to-array';
+import { toBST } from '../functions/to-binary-search-tree';
+import { BST } from '../types';
 import { compare, mockedArray, mockedUnbalancedTree } from './_mocks';
 
 describe('remove', () => {
-    const boundRemove = makeRemove(compare);
+    const { remove: boundRemove } = makeCompareUtils(compare);
 
     it('should not remove a node which is not there', () => {
         const tree = remove(mockedUnbalancedTree, compare, 86);
@@ -18,6 +22,14 @@ describe('remove', () => {
 
         const treeBound = boundRemove({ data: [] }, 86);
         expect(treeBound).toEqual({ data: [] });
+    });
+
+    it('should not mutate the original tree', () => {
+        const tree = remove(mockedUnbalancedTree, compare, [10, 2]);
+        const updatedTree = remove(tree as BST<number>, compare, [89, 50]);
+
+        expect(toArrayInOrder(tree).length).toBe(5);
+        expect(toArrayInOrder(updatedTree).length).toBe(3);
     });
 
     it('should remove a leaf correctly', () => {
@@ -100,5 +112,25 @@ describe('remove', () => {
 
         const treeBound = boundRemove(mockedUnbalancedTree, mockedArray);
         expect(treeBound).toEqual({ data: [] });
+    });
+
+    it('should preserve the node if the comparison does not match all elements of the node', () => {
+        type Hero = { age: number; name: string };
+        const compareNameAlpha = (a: Hero, b: Hero) => a.name.localeCompare(b.name);
+
+        const removerElement = { name: 'Anakin', age: 28 };
+
+        const tree = toBST(
+            [
+                { name: 'Anakin', age: 28 },
+                { name: 'Anakin', age: 27 },
+                { name: 'Leia', age: 2 },
+            ],
+            (a, b) => a.name.localeCompare(b.name)
+        );
+
+        const modifiedTree = remove(tree, compareNameAlpha, removerElement);
+
+        expect(modifiedTree?.data?.[0]).toEqual({ name: 'Anakin', age: 27 });
     });
 });

--- a/src/__tests__/remove.test.ts
+++ b/src/__tests__/remove.test.ts
@@ -13,45 +13,37 @@ describe('remove', () => {
     });
 
     it('should not remove an empty node', () => {
-        const tree = remove({ data: undefined }, compare, 86);
-        expect(tree).toEqual({});
+        const tree = remove({ data: [] }, compare, 86);
+        expect(tree).toEqual({ data: [] });
 
-        const treeBound = boundRemove({ data: undefined }, 86);
-        expect(treeBound).toEqual({});
-    });
-
-    it('should work with undefined', () => {
-        const tree = remove(undefined, compare, 86);
-        expect(tree).toEqual({});
-
-        const treeBound = boundRemove(undefined, 86);
-        expect(treeBound).toEqual({});
+        const treeBound = boundRemove({ data: [] }, 86);
+        expect(treeBound).toEqual({ data: [] });
     });
 
     it('should remove a leaf correctly', () => {
         const tree = remove(mockedUnbalancedTree, compare, 50);
-        expect(tree?.right?.right?.data).toBe(89);
-        expect(tree?.right?.right?.left?.data).toBe(undefined);
+        expect(tree?.right?.right?.data[0]).toBe(89);
+        expect(tree?.right?.right?.left?.data[0]).toBe(undefined);
 
         const treeBound = boundRemove(mockedUnbalancedTree, 50);
-        expect(treeBound?.right?.right?.data).toBe(89);
-        expect(treeBound?.right?.right?.left?.data).toBe(undefined);
+        expect(treeBound?.right?.right?.data[0]).toBe(89);
+        expect(treeBound?.right?.right?.left?.data[0]).toBe(undefined);
     });
 
     it('should remove a single branch with left node correctly', () => {
         const tree = remove(mockedUnbalancedTree, compare, 89);
-        expect(tree?.right?.right?.data).toBe(50);
+        expect(tree?.right?.right?.data[0]).toBe(50);
 
         const treeBound = boundRemove(mockedUnbalancedTree, 89);
-        expect(treeBound?.right?.right?.data).toBe(50);
+        expect(treeBound?.right?.right?.data[0]).toBe(50);
     });
 
     it('should remove a single branch with right node correctly', () => {
         const tree = remove(mockedUnbalancedTree, compare, 2);
-        expect(tree?.left?.data).toBe(5);
+        expect(tree?.left?.data[0]).toBe(5);
 
         const treeBound = boundRemove(mockedUnbalancedTree, 2);
-        expect(treeBound?.left?.data).toBe(5);
+        expect(treeBound?.left?.data[0]).toBe(5);
     });
 
     it('should remove a branch with both left and right nodes correctly', () => {
@@ -66,32 +58,32 @@ describe('remove', () => {
         const tree = remove(mockedUnbalancedTree, compare, 10);
         const treeUpdated = remove(tree, compare, 13);
 
-        expect(tree?.data).toBe(13);
-        expect(tree?.left?.data).toBe(2);
-        expect(tree?.left?.right?.data).toBe(5);
-        expect(tree?.right?.data).toBe(32);
-        expect(tree?.right?.right?.data).toBe(89);
-        expect(tree?.right?.right?.left?.data).toBe(50);
-        expect(treeUpdated?.data).toBe(32);
-        expect(treeUpdated?.left?.data).toBe(2);
-        expect(treeUpdated?.left?.right?.data).toBe(5);
-        expect(treeUpdated?.right?.data).toBe(89);
-        expect(treeUpdated?.right?.left?.data).toBe(50);
+        expect(tree?.data[0]).toBe(13);
+        expect(tree?.left?.data[0]).toBe(2);
+        expect(tree?.left?.right?.data[0]).toBe(5);
+        expect(tree?.right?.data[0]).toBe(32);
+        expect(tree?.right?.right?.data[0]).toBe(89);
+        expect(tree?.right?.right?.left?.data[0]).toBe(50);
+        expect(treeUpdated?.data[0]).toBe(32);
+        expect(treeUpdated?.left?.data[0]).toBe(2);
+        expect(treeUpdated?.left?.right?.data[0]).toBe(5);
+        expect(treeUpdated?.right?.data[0]).toBe(89);
+        expect(treeUpdated?.right?.left?.data[0]).toBe(50);
 
         const treeBound = boundRemove(mockedUnbalancedTree, 10);
         const treeUpdatedBound = boundRemove(treeBound, 13);
 
-        expect(treeBound?.data).toBe(13);
-        expect(treeBound?.left?.data).toBe(2);
-        expect(treeBound?.left?.right?.data).toBe(5);
-        expect(treeBound?.right?.data).toBe(32);
-        expect(treeBound?.right?.right?.data).toBe(89);
-        expect(treeBound?.right?.right?.left?.data).toBe(50);
-        expect(treeUpdatedBound?.data).toBe(32);
-        expect(treeUpdatedBound?.left?.data).toBe(2);
-        expect(treeUpdatedBound?.left?.right?.data).toBe(5);
-        expect(treeUpdatedBound?.right?.data).toBe(89);
-        expect(treeUpdatedBound?.right?.left?.data).toBe(50);
+        expect(treeBound?.data[0]).toBe(13);
+        expect(treeBound?.left?.data[0]).toBe(2);
+        expect(treeBound?.left?.right?.data[0]).toBe(5);
+        expect(treeBound?.right?.data[0]).toBe(32);
+        expect(treeBound?.right?.right?.data[0]).toBe(89);
+        expect(treeBound?.right?.right?.left?.data[0]).toBe(50);
+        expect(treeUpdatedBound?.data[0]).toBe(32);
+        expect(treeUpdatedBound?.left?.data[0]).toBe(2);
+        expect(treeUpdatedBound?.left?.right?.data[0]).toBe(5);
+        expect(treeUpdatedBound?.right?.data[0]).toBe(89);
+        expect(treeUpdatedBound?.right?.left?.data[0]).toBe(50);
     });
 
     it('should not remove a node which is not there', () => {
@@ -102,19 +94,11 @@ describe('remove', () => {
         expect(treeBound).toEqual(mockedUnbalancedTree);
     });
 
-    it('should work with undefined', () => {
-        const tree = remove(undefined, compare, [86]);
-        expect(tree).toEqual({});
-
-        const treeBound = boundRemove(undefined, [86]);
-        expect(treeBound).toEqual({});
-    });
-
     it('should empty the tree correctly', () => {
         const tree = remove(mockedUnbalancedTree, compare, mockedArray);
-        expect(tree).toEqual({});
+        expect(tree).toEqual({ data: [] });
 
         const treeBound = boundRemove(mockedUnbalancedTree, mockedArray);
-        expect(treeBound).toEqual({});
+        expect(treeBound).toEqual({ data: [] });
     });
 });

--- a/src/__tests__/to-binary-search-tree.test.ts
+++ b/src/__tests__/to-binary-search-tree.test.ts
@@ -1,17 +1,16 @@
-import { toBST } from '../functions/to-binary-search-tree';
-import {
-    compare,
-    mockedArray,
-    mockedBalancedTree,
-    mockedUnbalancedTree,
-} from './_mocks';
+import { makeToBST, toBST } from '../functions/to-binary-search-tree';
+import { compare, mockedArray, mockedBalancedTree, mockedUnbalancedTree } from './_mocks';
 
 describe('toBST', () => {
+    const boundToBST = makeToBST(compare);
+
     it('should return a correct balanced binary search tree', () => {
         expect(toBST(mockedArray, compare)).toEqual(mockedBalancedTree);
+        expect(boundToBST(mockedArray)).toEqual(mockedBalancedTree);
     });
 
     it('should return a correct unbalanced binary search tree', () => {
         expect(toBST(mockedArray, compare, { isBalanced: false })).toEqual(mockedUnbalancedTree);
+        expect(boundToBST(mockedArray, { isBalanced: false })).toEqual(mockedUnbalancedTree);
     });
 });

--- a/src/classes/binary-search-tree.ts
+++ b/src/classes/binary-search-tree.ts
@@ -71,12 +71,12 @@ export class BinarySearchTree<T> {
     };
 
     public readonly remove = (elements: T | T[]) => {
-        this.t = removeNode(this.t, this.compare, elements) || {};
+        this.t = removeNode(this.t, this.compare, elements) || { data: [] };
         return this;
     };
 
     public readonly clear = () => {
-        this.t = {};
+        this.t = { data: [] };
         return this;
     };
 
@@ -141,16 +141,16 @@ export class BinarySearchTree<T> {
     public readonly isBalanced = () => isBalancedTree(this.t);
 
     public readonly hasLeft = (element: T) =>
-        hasLeftNode(findNode(this.t, this.compare, element)?.node);
+        hasLeftNode(findNode(this.t, this.compare, element)?.node || { data: [] });
 
     public readonly hasRight = (element: T) =>
-        hasRightNode(findNode(this.t, this.compare, element)?.node);
+        hasRightNode(findNode(this.t, this.compare, element)?.node || { data: [] });
 
     public readonly isBranch = (element: T) =>
-        isBranchNode(findNode(this.t, this.compare, element)?.node);
+        isBranchNode(findNode(this.t, this.compare, element)?.node || { data: [] });
 
     public readonly isLeaf = (element: T) =>
-        isLeafNode(findNode(this.t, this.compare, element)?.node);
+        isLeafNode(findNode(this.t, this.compare, element)?.node || { data: [] });
 
     // Finders
     public readonly find = (element: T) => findNode(this.t, this.compare, element);

--- a/src/functions/add.ts
+++ b/src/functions/add.ts
@@ -1,14 +1,14 @@
 import { BST, CompareFunction, Direction } from '../types';
 
 function addElement<T>(tree: BST<T>, compare: CompareFunction<T>, element: T): BST<T> {
-    if (tree.data === undefined) {
-        return { data: element };
+    if (tree.data.length === 0) {
+        return { data: [element] };
     }
 
-    const comparison = compare(element, tree.data);
+    const comparison = compare(element, tree.data[0]);
 
     if (comparison === 0) {
-        return tree;
+        return { ...tree, data: [...tree.data, element] };
     }
 
     const direction = comparison < 0 ? Direction.Left : Direction.Right;
@@ -16,32 +16,33 @@ function addElement<T>(tree: BST<T>, compare: CompareFunction<T>, element: T): B
 
     return {
         ...tree,
-        [direction] : subTree ? addElement(subTree, compare, element) : { data: element },
+        [direction] : subTree ? addElement(subTree, compare, element) : { data: [element] },
     };
 }
 
 // Impure, but way more efficient, pass a precloned tree in order to ensure immutablibilty
 function addElementImpure<T>(tree: BST<T>, compare: CompareFunction<T>, element: T): void {
-    if (tree.data === undefined) {
-        tree.data = element;
-    }
+    if (tree.data.length === 0) {
+        tree.data = [element];
+    } else {
+        let currentNode = tree;
 
-    let currentNode = tree;
+        while (true) {
+            const comparison = compare(element, currentNode.data[0]);
 
-    while (true) {
-        const comparison = compare(element, currentNode.data as T);
+            if (comparison === 0) {
+                currentNode.data.push(element);
+                break;
+            }
 
-        if (comparison === 0) {
-            break;
-        }
+            const direction = comparison < 0 ? Direction.Left : Direction.Right;
 
-        const direction = comparison < 0 ? Direction.Left : Direction.Right;
-
-        if (currentNode[direction]) {
-            currentNode = currentNode[direction]!;
-        } else {
-            currentNode[direction] = { data: element };
-            break;
+            if (currentNode[direction]) {
+                currentNode = currentNode[direction]!;
+            } else {
+                currentNode[direction] = { data: [element] };
+                break;
+            }
         }
     }
 }

--- a/src/functions/find.ts
+++ b/src/functions/find.ts
@@ -24,11 +24,11 @@ export function find<T>(
     element: T,
     path = [] as Direction[]
 ): FoundResult<T> | undefined {
-    if (tree.data === undefined) {
+    if (tree.data.length === 0) {
         return undefined;
     }
 
-    const comparison = compare(element, tree.data);
+    const comparison = compare(element, tree.data[0]);
 
     if (comparison === 0) {
         return { node: tree, path };

--- a/src/functions/has-left.ts
+++ b/src/functions/has-left.ts
@@ -1,4 +1,4 @@
-import { BST, BSTLeftBranch } from '../types';
+import { BST, BSTBranchWithLeft } from '../types';
 
 /**
  * Assesses if the given tree has a left branch (has left).
@@ -7,6 +7,6 @@ import { BST, BSTLeftBranch } from '../types';
  *
  * @returns true if it has, false if it hasn't.
  */
-export function hasLeft<T>(tree?: BST<T>): tree is BSTLeftBranch<T> {
-    return tree?.data !== undefined && !!tree.left;
+export function hasLeft<T>(tree: BST<T>): tree is BSTBranchWithLeft<T> {
+    return tree.data.length > 0 && !!tree.left;
 }

--- a/src/functions/has-right.ts
+++ b/src/functions/has-right.ts
@@ -1,4 +1,4 @@
-import { BST, BSTRightBranch } from '../types';
+import { BST, BSTBranchWithRight } from '../types';
 
 /**
  * Assesses if the given tree has a right branch (has right).
@@ -7,6 +7,6 @@ import { BST, BSTRightBranch } from '../types';
  *
  * @returns true if it has, false if it hasn't.
  */
-export function hasRight<T>(tree?: BST<T>): tree is BSTRightBranch<T> {
-    return tree?.data !== undefined && !!tree.right;
+export function hasRight<T>(tree: BST<T>): tree is BSTBranchWithRight<T> {
+    return tree.data.length > 0 && !!tree.right;
 }

--- a/src/functions/is-branch.ts
+++ b/src/functions/is-branch.ts
@@ -9,6 +9,6 @@ import { hasRight } from './has-right';
  *
  * @returns true if it is, false if it isn't.
  */
-export function isBranch<T>(tree?: BST<T>): tree is BSTBranch<T> {
+export function isBranch<T>(tree: BST<T>): tree is BSTBranch<T> {
     return hasLeft(tree) || hasRight(tree);
 }

--- a/src/functions/is-leaf.ts
+++ b/src/functions/is-leaf.ts
@@ -7,6 +7,6 @@ import { BST, BSTLeaf } from '../types';
  *
  * @returns true if it is, false if it isn't.
  */
-export function isLeaf<T>(tree?: BST<T>): tree is BSTLeaf<T> {
-    return tree?.data !== undefined && !tree.left && !tree.right;
+export function isLeaf<T>(tree: BST<T>): tree is BSTLeaf<T> {
+    return tree.data.length > 0 && !tree.left && !tree.right;
 }

--- a/src/functions/remove.ts
+++ b/src/functions/remove.ts
@@ -4,6 +4,10 @@ import { hasLeft } from './has-left';
 import { hasRight } from './has-right';
 import { isLeaf } from './is-leaf';
 
+function matchesElement<T extends object>(source: T, target: T): boolean {
+    return !Object.keys(source).some((key) => target[key as keyof T] !== source[key as keyof T]);
+}
+
 function removeElement<T>(
     tree = {} as BST<T>,
     compare: CompareFunction<T>,
@@ -17,15 +21,13 @@ function removeElement<T>(
 
     // This node matches
     if (comparison === 0) {
-        if (tree.data.length > 1 && typeof element === 'object') {
-            return {
-                ...tree,
-                data : tree.data.filter((el) =>
-                    Object.keys(element).some(
-                        (key) => el[key as keyof T] !== element[key as keyof T]
-                    )
-                ),
-            };
+        const newData =
+            typeof element === 'object'
+                ? tree.data.filter((target) => !matchesElement(element, target as object))
+                : [];
+
+        if (newData.length > 0) {
+            return { ...tree, data: newData };
         }
 
         if (isLeaf(tree)) {
@@ -33,6 +35,7 @@ function removeElement<T>(
             // => Just delete.
             return undefined;
         }
+
         if (hasLeft(tree) && hasRight(tree)) {
             // If two children:
             // => Determine the next inorder successor in the right subtree.
@@ -46,7 +49,7 @@ function removeElement<T>(
                 right : removeElement(
                     tree.right as BST<T>,
                     compare,
-                    nextInOrder.data as T
+                    nextInOrder.data[0] as T
                 ) as BST<T>,
             };
         }

--- a/src/functions/remove.ts
+++ b/src/functions/remove.ts
@@ -1,4 +1,4 @@
-import { BST, BSTNode, CompareFunction, Direction } from '../types';
+import { BST, CompareFunction, Direction } from '../types';
 import { findMin } from './find-min';
 import { hasLeft } from './has-left';
 import { hasRight } from './has-right';
@@ -9,14 +9,25 @@ function removeElement<T>(
     compare: CompareFunction<T>,
     element: T
 ): BST<T> | undefined {
-    if (tree?.data === undefined) {
+    if (element == null || tree.data.length === 0) {
         return tree;
     }
 
-    const comparison = compare(element, tree.data);
+    const comparison = compare(element, tree.data[0]);
 
-    // This node should be removed
+    // This node matches
     if (comparison === 0) {
+        if (tree.data.length > 1 && typeof element === 'object') {
+            return {
+                ...tree,
+                data : tree.data.filter((el) =>
+                    Object.keys(element).some(
+                        (key) => el[key as keyof T] !== element[key as keyof T]
+                    )
+                ),
+            };
+        }
+
         if (isLeaf(tree)) {
             // If no children:
             // => Just delete.
@@ -33,10 +44,10 @@ function removeElement<T>(
                 ...tree,
                 data  : nextInOrder.data,
                 right : removeElement(
-                    tree.right as BSTNode<T>,
+                    tree.right as BST<T>,
                     compare,
                     nextInOrder.data as T
-                ) as BSTNode<T>,
+                ) as BST<T>,
             };
         }
 
@@ -56,7 +67,7 @@ function removeElements<T>(
     compare: CompareFunction<T>,
     elements: T[]
 ): BST<T> {
-    return elements.reduce((acc, curr) => removeElement(acc, compare, curr) || {}, tree);
+    return elements.reduce((acc, curr) => removeElement(acc, compare, curr) || { data: [] }, tree);
 }
 
 /**

--- a/src/functions/to-binary-search-tree.ts
+++ b/src/functions/to-binary-search-tree.ts
@@ -29,7 +29,7 @@ export function toBST<T>(
     } as BinarySearchTreeOptions
 ): BST<T> {
     if (!isBalanced) {
-        return add({}, compare, elements);
+        return add({ data: [] }, compare, elements);
     }
 
     const sortedElements = isPresorted ? elements : elements.slice().sort(compare);
@@ -39,11 +39,11 @@ export function toBST<T>(
 
     forEachBalanced(collectElement, sortedElements);
 
-    return add({}, compare, balancedElements);
+    return add({ data: [] }, compare, balancedElements);
 }
 
 export function makeToBST<T>(compare: CompareFunction<T>) {
-    return function (elements: T[], options: BinarySearchTreeOptions) {
+    return function (elements: T[], options?: BinarySearchTreeOptions) {
         return toBST(elements, compare, options);
     };
 }

--- a/src/functions/traverse-in-order.ts
+++ b/src/functions/traverse-in-order.ts
@@ -7,7 +7,7 @@ import { BST } from '../types';
  * @param tree the tree to traverse
  */
 export function traverseInOrder<T>(cb: (node: BST<T>) => void, tree?: BST<T>): void {
-    if (tree?.data !== undefined) {
+    if (!!tree?.data?.length) {
         traverseInOrder(cb, tree.left);
         cb(tree);
         traverseInOrder(cb, tree.right);
@@ -21,7 +21,7 @@ export function traverseInOrder<T>(cb: (node: BST<T>) => void, tree?: BST<T>): v
  * @param tree the tree to traverse
  */
 export function traverseInOrderReverse<T>(cb: (node: BST<T>) => void, tree?: BST<T>): void {
-    if (tree?.data !== undefined) {
+    if (!!tree?.data?.length) {
         traverseInOrderReverse(cb, tree.right);
         cb(tree);
         traverseInOrderReverse(cb, tree.left);

--- a/src/functions/traverse-level-order.ts
+++ b/src/functions/traverse-level-order.ts
@@ -7,7 +7,7 @@ import { BST } from '../types';
  * @param tree the tree to traverse
  */
 export function traverseLevelOrder<T>(cb: (node: BST<T>) => void, tree?: BST<T>): void {
-    if (tree?.data !== undefined) {
+    if (!!tree?.data?.length) {
         const queue: BST<T>[] = [tree];
 
         while (queue.length > 0) {
@@ -33,7 +33,7 @@ export function traverseLevelOrder<T>(cb: (node: BST<T>) => void, tree?: BST<T>)
  * @param tree the tree to traverse
  */
 export function traverseLevelOrderReverse<T>(cb: (node: BST<T>) => void, tree?: BST<T>): void {
-    if (tree?.data !== undefined) {
+    if (!!tree?.data?.length) {
         const queue: BST<T>[] = [tree];
 
         while (queue.length > 0) {

--- a/src/functions/traverse-post-order.ts
+++ b/src/functions/traverse-post-order.ts
@@ -7,7 +7,7 @@ import { BST } from '../types';
  * @param tree the tree to traverse
  */
 export function traversePostOrder<T>(cb: (node: BST<T>) => void, tree?: BST<T>): void {
-    if (tree?.data !== undefined) {
+    if (!!tree?.data?.length) {
         traversePostOrder(cb, tree.left);
         traversePostOrder(cb, tree.right);
         cb(tree);
@@ -21,7 +21,7 @@ export function traversePostOrder<T>(cb: (node: BST<T>) => void, tree?: BST<T>):
  * @param tree the tree to traverse
  */
 export function traversePostOrderReverse<T>(cb: (node: BST<T>) => void, tree?: BST<T>): void {
-    if (tree?.data !== undefined) {
+    if (!!tree?.data?.length) {
         traversePostOrderReverse(cb, tree.right);
         traversePostOrderReverse(cb, tree.left);
         cb(tree);

--- a/src/functions/traverse-pre-order.ts
+++ b/src/functions/traverse-pre-order.ts
@@ -7,7 +7,7 @@ import { BST } from '../types';
  * @param tree the tree to traverse
  */
 export function traversePreOrder<T>(cb: (node: BST<T>) => void, tree?: BST<T>): void {
-    if (tree?.data !== undefined) {
+    if (!!tree?.data?.length) {
         cb(tree);
         traversePreOrder(cb, tree.left);
         traversePreOrder(cb, tree.right);
@@ -21,7 +21,7 @@ export function traversePreOrder<T>(cb: (node: BST<T>) => void, tree?: BST<T>): 
  * @param tree the tree to traverse
  */
 export function traversePreOrderReverse<T>(cb: (node: BST<T>) => void, tree?: BST<T>): void {
-    if (tree?.data !== undefined) {
+    if (!!tree?.data?.length) {
         cb(tree);
         traversePreOrderReverse(cb, tree.right);
         traversePreOrderReverse(cb, tree.left);

--- a/src/helpers/collect.ts
+++ b/src/helpers/collect.ts
@@ -2,8 +2,8 @@ import { BST, FoundResult } from '../types';
 
 export function makeCollectElementFromNode<T>(elements: T[]) {
     return function collectElementFromNode(node?: BST<T>) {
-        if (node?.data) {
-            elements.push(node.data);
+        if (!!node?.data.length) {
+            node.data.forEach((e) => elements.push(e));
         }
     };
 }

--- a/src/helpers/for-each-balanced.ts
+++ b/src/helpers/for-each-balanced.ts
@@ -1,16 +1,40 @@
-export function forEachBalanced<T>(cb: (element: T) => void, sortedElements: T[]): void {
-    const length = sortedElements.length;
-    const half = length / 2;
+// export function forEachBalanced<T>(cb: (element: T) => void, sortedElements: T[]): void {
+//     const length = sortedElements.length;
+//     const half = length / 2;
 
-    const lefts = sortedElements.slice(0, Math.ceil(half - 0.5) + 1);
-    const rights = sortedElements.slice(Math.floor(half));
+//     const lefts = sortedElements.slice(0, Math.ceil(half - 0.5) + 1);
+//     const rights = sortedElements.slice(Math.floor(half));
 
-    if (lefts.length > 0) {
-        cb(lefts.pop() as T);
-        forEachBalanced(cb, lefts);
+//     if (lefts.length > 0) {
+//         cb(lefts.pop() as T);
+//         forEachBalanced(cb, lefts);
+//     }
+//     if (rights.length > 0) {
+//         cb(rights.shift() as T);
+//         forEachBalanced(cb, rights);
+//     }
+// }
+
+// [1, 2, 3, 4, 5, 6, 7] => 3
+// [1, 2, 3, 4, 5, 6] => 3
+
+export function forEachBalanced<T>(
+    cb: (element: T) => void,
+    sortedElements: T[],
+    range?: [number, number]
+): void {
+    const l = range?.[0] === undefined ? 0 : range[0];
+    const r = range?.[1] === undefined ? sortedElements.length - 1 : range[1];
+
+    if (l > r) {
+        return;
     }
-    if (rights.length > 0) {
-        cb(rights.shift() as T);
-        forEachBalanced(cb, rights);
-    }
+
+    const half = Math.ceil((l + r) / 2);
+
+    cb(sortedElements[half]);
+
+    forEachBalanced(cb, sortedElements, [l, half - 1]);
+
+    forEachBalanced(cb, sortedElements, [half + 1, r]);
 }

--- a/src/helpers/make-find-many-traversal.ts
+++ b/src/helpers/make-find-many-traversal.ts
@@ -14,11 +14,11 @@ export function makeFindManyTraversal({
         element: T,
         path = [] as Direction[]
     ): void {
-        if (tree.data === undefined) {
+        if (tree.data.length === 0) {
             return undefined;
         }
 
-        const comparison = compare(element, tree.data);
+        const comparison = compare(element, tree.data[0]);
 
         if (shouldFindCurrent(comparison)) {
             cb({ node: tree, path });

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,4 +33,4 @@ export { traverseInOrder, traverseInOrderReverse } from './functions/traverse-in
 export { traverseLevelOrder, traverseLevelOrderReverse } from './functions/traverse-level-order';
 export { traversePostOrder, traversePostOrderReverse } from './functions/traverse-post-order';
 export { traversePreOrder, traversePreOrderReverse } from './functions/traverse-pre-order';
-export type { BST, BSTLeaf, BSTNode, CompareFunction } from './types';
+export type { BST, BSTLeaf, CompareFunction } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,18 +15,21 @@ export type FindManyTraversalOptions = {
 
 export type BinarySearchTreeOptions = { isBalanced?: boolean; isPresorted?: boolean };
 
-export type BSTLeaf<T> = { data: T };
+export type BST<T> = {
+    data               : T[];
+    [Direction.Left]?  : BST<T>;
+    [Direction.Right]? : BST<T>;
+};
 
-export type BSTLeftBranch<T> = { [Direction.Left]: BSTNode<T> };
+export type BSTLeaf<T> = Omit<BST<T>, Direction> & {
+    [Direction.Left]?  : never;
+    [Direction.Right]? : never;
+};
 
-export type BSTRightBranch<T> = { [Direction.Right]: BSTNode<T> };
+export type BSTBranchWithLeft<T> = Omit<BST<T>, Direction.Left> & { [Direction.Left]: BST<T> };
 
-export type BSTBranch<T> = BSTLeaf<T> &
-    (
-        | (BSTLeftBranch<T> & Partial<BSTRightBranch<T>>)
-        | (BSTRightBranch<T> & Partial<BSTLeftBranch<T>>)
-    );
+export type BSTBranchWithRight<T> = Omit<BST<T>, Direction.Right> & { [Direction.Right]: BST<T> };
 
-export type BSTNode<T> = BSTLeaf<T> & Omit<Partial<BSTBranch<T>>, 'data'>;
-
-export type BST<T> = Partial<BSTNode<T>>;
+export type BSTBranch<T> =
+    | (BSTBranchWithLeft<T> & Partial<BSTBranchWithRight<T>>)
+    | (BSTBranchWithRight<T> & Partial<BSTBranchWithLeft<T>>);


### PR DESCRIPTION
As the binary search tree is composed from the compare function, two different elements resolved as similar by the comparison would thus exclude the second from the tree.
To resolve this, data should be converted to an array of elements matching the node.